### PR TITLE
Add contets:write permissions for createing new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: write
+  # packages: write
 jobs:
   draft_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since Github changed default permissions for new repository to read only, we needs to add contents:write for creating new releases.