### PR TITLE
Remove duplicate renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,18 +3,7 @@
   "extends": [
     "github>Kesin11/renovate-config:oss",
     ":prConcurrentLimit10",
-    ":enableVulnerabilityAlerts",
     "schedule:weekends"
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": ["^(Docker|Earth)file.*$"],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
-      ],
-      "extractVersionTemplate": "^v?(?<version>.*)$",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
   ],
   "packageRules": [
     {


### PR DESCRIPTION
I added regexManager config (#27, #29) into my renovate preset repository. So remove these duplicate config.

ref: https://github.com/Kesin11/renovate-config/pull/1